### PR TITLE
Rubocop: fix rubocop on master

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,6 @@ AllCops:
   TargetRubyVersion: 2.4
 Rails: { Enabled: true }
 
+Metrics/BlockLength: { Exclude: [db/schema.rb, spec/**/*_spec.rb] }
+Rails/HasManyOrHasOneDependent: { Enabled: false }
+Style/Documentation: { Enabled: false }

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -55,11 +55,6 @@ Layout/SpaceInsideBlockBraces:
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
 
-# Offense count: 2
-# Configuration parameters: CountComments, ExcludedMethods.
-Metrics/BlockLength:
-  Max: 32
-
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
@@ -86,13 +81,8 @@ Rails/FilePath:
   Exclude:
     - 'config/environments/development.rb'
 
-# Offense count: 2
-# Configuration parameters: Include.
-# Include: app/models/**/*.rb
-Rails/HasManyOrHasOneDependent:
-  Exclude:
-    - 'app/models/currency.rb'
-    - 'app/models/listing.rb'
+Rails/InverseOf:
+  Enabled: false
 
 # Offense count: 1
 # Cop supports --auto-correct.
@@ -107,25 +97,6 @@ Style/BlockComments:
 Style/ClassAndModuleChildren:
   Exclude:
     - 'test/test_helper.rb'
-
-# Offense count: 13
-Style/Documentation:
-  Exclude:
-    - 'spec/**/*'
-    - 'test/**/*'
-    - 'app/controllers/application_controller.rb'
-    - 'app/controllers/listings_controller.rb'
-    - 'app/helpers/application_helper.rb'
-    - 'app/helpers/locations_helper.rb'
-    - 'app/mailers/application_mailer.rb'
-    - 'app/models/application_record.rb'
-    - 'app/models/currency.rb'
-    - 'app/models/currency_listing.rb'
-    - 'app/models/listing.rb'
-    - 'config/application.rb'
-    - 'db/migrate/20180303010220_create_listings.rb'
-    - 'db/migrate/20180304041947_create_currencies.rb'
-    - 'db/migrate/20180304043236_create_currency_listings.rb'
 
 # Offense count: 54
 # Cop supports --auto-correct.

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -3,5 +3,5 @@ class Listing < ApplicationRecord
 
   has_many :currency_listings
   has_many :currencies, through: :currency_listings
-  belongs_to :submitter, class_name: :User#, inverse_of: :user
+  belongs_to :submitter, class_name: :User # , inverse_of: :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
   validates :display_name, :email, :password_digest, presence: true
 
-  has_many :submissions, class_name: :Listing, foreign_key: :submitter_id#, inverse_of: :listing
+  has_many :submissions, class_name: :Listing, foreign_key: :submitter_id # , inverse_of: :listing
 end

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe ListingsController do
 
-  let!(:satoshi) { User.create(display_name: "satoshi", email: "satoshi@bitcoin.org", password_digest: "123456")}
+  let!(:satoshi) { User.create(display_name: "satoshi", email: "satoshi@bitcoin.org", password_digest: "123456") }
   let!(:listing) { Listing.create(name: "Pizza House", submitter_id: satoshi.id) }
   before { subject }
 


### PR DESCRIPTION
- `Metrics/BlockLength` limits the allowed length of `do`/`end` blocks.
  Excluded `db/schema.rb` and our specs, since they have legitimately
  long blocks.
- `Rails/HasManyOrHasOneDependent` has been disabled. This rule enforces
  that we always have a `dependent:` option on `has_many` or `has_one`
  relations. Something like `dependent: :destroy` or `dependent:
  :nullify`. I'm of the camp that we ought to be very careful what we
  destroy, because having relations implicitly deleted when a top level
  resource is deleted can have a lot of unintended side effects as the
  number of connected relationships grows in an app. Aside from
  potentially deleting a lot of extra data, it can also cause N+1
  queries against the database. Better to instead add explicit logic for
  how a deletion should be executed.
- `Style/Documentation` requires that we add documentation comments in
  all of our classes. Not sure if we want to bother with this at the
  moment, so left it disabled.
- `Rails/InverseOf` is temporarily disabled.