### PR TITLE
Rubocop: enable spacing rules

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -7,63 +7,9 @@
 # versions of RuboCop, may require this file to be generated again.
 
 # Offense count: 1
-# Cop supports --auto-correct.
-Layout/EmptyLines:
-  Exclude:
-    - 'bin/setup'
-
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: empty_lines, no_empty_lines
-Layout/EmptyLinesAroundBlockBody:
-  Exclude:
-    - 'db/schema.rb'
-    - 'spec/controllers/listings_controller_spec.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
-Layout/EmptyLinesAroundClassBody:
-  Exclude:
-    - 'test/controllers/locations_controller_test.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBrackets.
-# SupportedStyles: space, no_space, compact
-# SupportedStylesForEmptyBrackets: space, no_space
-Layout/SpaceInsideArrayLiteralBrackets:
-  Exclude:
-    - 'config/environments/production.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces, SpaceBeforeBlockParameters.
-# SupportedStyles: space, no_space
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceInsideBlockBraces:
-  Exclude:
-    - 'spec/models/currency_spec.rb'
-
-# Offense count: 6
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForEmptyBraces.
-# SupportedStyles: space, no_space, compact
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
-
-# Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
   Max: 14
-
-# Offense count: 1
-RSpec/EmptyLineAfterFinalLet:
-  Exclude:
-    - 'spec/controllers/listings_controller_spec.rb'
 
 # Offense count: 10
 # Configuration parameters: .

--- a/bin/setup
+++ b/bin/setup
@@ -21,7 +21,6 @@ chdir APP_ROOT do
   # Install JavaScript dependencies if using Yarn
   # system('bin/yarn')
 
-
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')
   #   cp 'config/database.yml.sample', 'config/database.yml'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20180304203102) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -59,5 +58,4 @@ ActiveRecord::Schema.define(version: 20180304203102) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
-
 end

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 describe ListingsController do
-
   let!(:satoshi) { User.create(display_name: "satoshi", email: "satoshi@bitcoin.org", password_digest: "123456") }
   let!(:listing) { Listing.create(name: "Pizza House", submitter_id: satoshi.id) }
+
   before { subject }
 
   describe "GET #index" do
@@ -27,7 +27,7 @@ describe ListingsController do
   end
 
   describe "GET #edit" do
-    subject { get :edit, params: {id: listing.id} }
+    subject { get :edit, params: { id: listing.id } }
 
     it "renders the index template" do
       expect(subject).to render_template :edit
@@ -39,7 +39,7 @@ describe ListingsController do
   end
 
   describe "POST #create" do
-    subject { get :create, params: {listing: {name: "Satoshi's Pub", submitter_id: satoshi.id}} }
+    subject { get :create, params: { listing: { name: "Satoshi's Pub", submitter_id: satoshi.id } } }
 
     it "adds a listing to the database" do
       expect(Listing.count).to eq 2

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -15,19 +15,19 @@ RSpec.describe UsersController, type: :controller do
 
   describe 'POST #create' do
     context 'when password confirmation matches' do
-      let(:user_params) { {display_name: 'AAntonop', email: 'andrea@mastering_bitcoin.com', password: 'permissionless', password_confirmation: 'permissionless'} }
+      let(:user_params) { { display_name: 'AAntonop', email: 'andrea@mastering_bitcoin.com', password: 'permissionless', password_confirmation: 'permissionless' } }
 
       it 'creates a new user account' do
-        post :create, params: {user: user_params}
+        post :create, params: { user: user_params }
         expect(assigns(:user).persisted?).to be true
       end
     end
 
     context 'when password confirmation does not match' do
-      let(:user_params) { {display_name: 'AAntonop', email: 'andrea@mastering_bitcoin.com', password: 'permissionless', password_confirmation: 'consenys'} }
+      let(:user_params) { { display_name: 'AAntonop', email: 'andrea@mastering_bitcoin.com', password: 'permissionless', password_confirmation: 'consenys' } }
 
       it 'does not create a new user account' do
-        post :create, params: {user: user_params}
+        post :create, params: { user: user_params }
         expect(assigns(:user).persisted?).to be false
       end
     end

--- a/spec/models/currency_spec.rb
+++ b/spec/models/currency_spec.rb
@@ -3,5 +3,5 @@ require 'rails_helper'
 RSpec.describe Currency, type: :model do
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:symbol) }
-  it { should have_many(:listings)}
+  it { should have_many(:listings) }
 end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -5,5 +5,4 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     get locations_index_url
     assert_response :success
   end
-
 end


### PR DESCRIPTION
- `Layout/EmptyLines` allows only one blank line in a row.
- `Layout/EmptyLinesAroundBlockBody` enforces either no empty lines or
  one empty line inside of `do`/`end` blocks.
- `Layout/EmptyLinesAroundClassBody` the same but for classes.
- The rest are about spacing inside hashes, blocks, and arrays.

These all have configurations that we can change. For example, on other
projects I've worked on we enforce that there is a blank line padding
class bodies with the `Layout/EmptyLinesAroundClassBody` rule. I don't
really have strong opinions one way or another on these which way we
enforce. My only strong opinion is *that* we enforce them one way or
another.

This also made changes to `db/schema.rb`. Being that this is an
auto-generated file I could go either way on whether we just ignore this
file from Rubocop. The approach I was thinking of here is that we can
enforce rules that are auto-fixable on auto-generated files. We can run
`rubocop -a` at the command line to auto-fix violations.