### PR TITLE
Rubocop: enable Rubocop-RSpec rules

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,17 +11,6 @@
 Metrics/MethodLength:
   Max: 14
 
-# Offense count: 10
-# Configuration parameters: .
-# SupportedStyles: is_expected, should
-RSpec/ImplicitExpect:
-  EnforcedStyle: should
-
-# Offense count: 4
-RSpec/NamedSubject:
-  Exclude:
-    - 'spec/controllers/listings_controller_spec.rb'
-
 # Offense count: 1
 Rails/FilePath:
   Exclude:

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -4,13 +4,11 @@ describe ListingsController do
   let!(:satoshi) { User.create(display_name: "satoshi", email: "satoshi@bitcoin.org", password_digest: "123456") }
   let!(:listing) { Listing.create(name: "Pizza House", submitter_id: satoshi.id) }
 
-  before { subject }
-
   describe "GET #index" do
-    subject { get :index }
+    before { get :index }
 
     it "renders the index template" do
-      expect(subject).to render_template :index
+      expect(response).to render_template :index
     end
 
     it "finds all listings in the db" do
@@ -19,18 +17,18 @@ describe ListingsController do
   end
 
   describe "GET #new" do
-    subject { get :new }
+    before { get :new }
 
     it "renders the new template" do
-      expect(subject).to render_template :new
+      expect(response).to render_template :new
     end
   end
 
   describe "GET #edit" do
-    subject { get :edit, params: { id: listing.id } }
+    before { get :edit, params: { id: listing.id } }
 
     it "renders the index template" do
-      expect(subject).to render_template :edit
+      expect(response).to render_template :edit
     end
 
     it "finds the correct listing" do
@@ -39,7 +37,7 @@ describe ListingsController do
   end
 
   describe "POST #create" do
-    subject { get :create, params: { listing: { name: "Satoshi's Pub", submitter_id: satoshi.id } } }
+    before { get :create, params: { listing: { name: "Satoshi's Pub", submitter_id: satoshi.id } } }
 
     it "adds a listing to the database" do
       expect(Listing.count).to eq 2

--- a/spec/models/currency_listing_spec.rb
+++ b/spec/models/currency_listing_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe CurrencyListing, type: :model do
-  it { should validate_presence_of(:currency_id) }
-  it { should validate_presence_of(:listing_id) }
-  it { should belong_to(:currency) }
-  it { should belong_to(:listing) }
+  it { is_expected.to validate_presence_of(:currency_id) }
+  it { is_expected.to validate_presence_of(:listing_id) }
+  it { is_expected.to belong_to(:currency) }
+  it { is_expected.to belong_to(:listing) }
 end

--- a/spec/models/currency_spec.rb
+++ b/spec/models/currency_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Currency, type: :model do
-  it { should validate_presence_of(:name) }
-  it { should validate_presence_of(:symbol) }
-  it { should have_many(:listings) }
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:symbol) }
+  it { is_expected.to have_many(:listings) }
 end

--- a/spec/models/listings_spec.rb
+++ b/spec/models/listings_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe Listing do
-  it { should validate_presence_of(:name) }
-  it { should validate_presence_of(:submitter_id) }
-  it { should have_many(:currencies) }
-  it { should belong_to(:submitter) }
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:submitter_id) }
+  it { is_expected.to have_many(:currencies) }
+  it { is_expected.to belong_to(:submitter) }
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  it { should validate_presence_of(:display_name) }
-  it { should validate_presence_of(:email) }
-  it { should validate_presence_of(:password_digest) }
-  it { should validate_uniqueness_of(:display_name) }
-  it { should validate_uniqueness_of(:email) }
-  it { should have_many(:submissions) }
+  it { is_expected.to validate_presence_of(:display_name) }
+  it { is_expected.to validate_presence_of(:email) }
+  it { is_expected.to validate_presence_of(:password_digest) }
+  it { is_expected.to validate_uniqueness_of(:display_name) }
+  it { is_expected.to validate_uniqueness_of(:email) }
+  it { is_expected.to have_many(:submissions) }
 end


### PR DESCRIPTION
- `RSpec/ImplicitExpect` says you should not use `should`.
- `RSpec/NamedSubject` wants you to name your subject if you refer to it
  at any point in your test. You can use `subject(:my_name) { ... }`. In
  this case I just refactored the tests some to avoid use of `subject`.
  Controller tests keep a reference to the response as `response` that
  can be used.