### PR TITLE
A few updates to the database schema

### DIFF
--- a/app/models/currencies_listing.rb
+++ b/app/models/currencies_listing.rb
@@ -1,4 +1,4 @@
-class CurrencyListing < ApplicationRecord
+class CurrenciesListing < ApplicationRecord
   acts_as_paranoid
 
   validates :currency_id, :listing_id, presence: true

--- a/app/models/currency.rb
+++ b/app/models/currency.rb
@@ -1,6 +1,6 @@
 class Currency < ApplicationRecord
   validates :name, :symbol, presence: true
 
-  has_many :currency_listings
-  has_many :listings, through: :currency_listings
+  has_many :currencies_listings
+  has_many :listings, through: :currencies_listings
 end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -1,7 +1,7 @@
 class Listing < ApplicationRecord
   validates :name, :submitter_id, presence: true
 
-  has_many :currency_listings
-  has_many :currencies, through: :currency_listings
+  has_many :currencies_listings
+  has_many :currencies, through: :currencies_listings
   belongs_to :submitter, class_name: :User # , inverse_of: :user
 end

--- a/db/migrate/20180305010436_add_foreign_key_constraints.rb
+++ b/db/migrate/20180305010436_add_foreign_key_constraints.rb
@@ -1,0 +1,7 @@
+class AddForeignKeyConstraints < ActiveRecord::Migration[5.1]
+  def change
+    add_foreign_key :currency_listings, :currencies
+    add_foreign_key :currency_listings, :listings
+    add_foreign_key :listings, :users, column: :submitter_id
+  end
+end

--- a/db/migrate/20180305010835_add_constraints.rb
+++ b/db/migrate/20180305010835_add_constraints.rb
@@ -1,0 +1,14 @@
+class AddConstraints < ActiveRecord::Migration[5.1]
+  def change
+    add_index :currency_listings, %i[currency_id listing_id], unique: true
+    change_column_null :currencies, :name, false
+    change_column_null :currencies, :symbol, false
+    change_column_null :currency_listings, :currency_id, false
+    change_column_null :currency_listings, :listing_id, false
+    change_column_null :listings, :name, false
+    change_column_null :listings, :submitter_id, false
+    change_column_null :users, :display_name, false
+    change_column_null :users, :email, false
+    change_column_null :users, :password_digest, false
+  end
+end

--- a/db/migrate/20180305011401_rename_curreny_listings.rb
+++ b/db/migrate/20180305011401_rename_curreny_listings.rb
@@ -1,0 +1,5 @@
+class RenameCurrenyListings < ActiveRecord::Migration[5.1]
+  def change
+    rename_table :currency_listings, :currencies_listings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,30 +10,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180304203102) do
+ActiveRecord::Schema.define(version: 20180305011401) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "currencies", force: :cascade do |t|
-    t.string "name"
-    t.string "symbol"
+    t.string "name", null: false
+    t.string "symbol", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "currency_listings", force: :cascade do |t|
-    t.integer "currency_id"
-    t.integer "listing_id"
+  create_table "currencies_listings", force: :cascade do |t|
+    t.integer "currency_id", null: false
+    t.integer "listing_id", null: false
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["currency_id"], name: "index_currency_listings_on_currency_id"
-    t.index ["deleted_at"], name: "index_currency_listings_on_deleted_at"
-    t.index ["listing_id"], name: "index_currency_listings_on_listing_id"
+    t.index %w[currency_id listing_id], name: "index_currencies_listings_on_currency_id_and_listing_id", unique: true
+    t.index ["currency_id"], name: "index_currencies_listings_on_currency_id"
+    t.index ["deleted_at"], name: "index_currencies_listings_on_deleted_at"
+    t.index ["listing_id"], name: "index_currencies_listings_on_listing_id"
   end
 
   create_table "listings", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.string "address"
     t.string "address2"
     t.string "city"
@@ -42,20 +43,24 @@ ActiveRecord::Schema.define(version: 20180304203102) do
     t.string "country"
     t.string "phone"
     t.string "url"
-    t.integer "submitter_id"
+    t.integer "submitter_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["submitter_id"], name: "index_listings_on_submitter_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "display_name"
+    t.string "display_name", null: false
     t.string "role"
-    t.string "email"
+    t.string "email", null: false
     t.string "first_name"
     t.string "last_name"
-    t.string "password_digest"
+    t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
+
+  add_foreign_key "currencies_listings", "currencies"
+  add_foreign_key "currencies_listings", "listings"
+  add_foreign_key "listings", "users", column: "submitter_id"
 end

--- a/spec/models/currencies_listing_spec.rb
+++ b/spec/models/currencies_listing_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CurrencyListing, type: :model do
+RSpec.describe CurrenciesListing, type: :model do
   it { is_expected.to validate_presence_of(:currency_id) }
   it { is_expected.to validate_presence_of(:listing_id) }
   it { is_expected.to belong_to(:currency) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  before do
+    User.create!(display_name: 'foo', email: 'bar', password_digest: 'butts')
+  end
+
   it { is_expected.to validate_presence_of(:display_name) }
   it { is_expected.to validate_presence_of(:email) }
   it { is_expected.to validate_presence_of(:password_digest) }


### PR DESCRIPTION
- Add foreign key constraints to foreign key columns. These help the
  database to ensure referential integrity. When there is a foreign key
  constraint, the database won't allow you to remove a record without
  dealing in one way or another with its associations. For example, if
  we delete a user record, we should decide what to do with their
  submitted listings rather than leaving an invalid `submitter_id`.
  Likewise, if we remove a `currency` or `listing`, we'll want to make
  sure we deal with the join records as well.
- Add a unique index on the join table for `currency_id` and
  `listing_id`. This will prevent any weird logic that tries to insert
  the same relation twice.
- add `NOT NULL` constraints to a bunch of columns that we presumably
  want to not be null. Some of these we may want to loosen at some
  point, but I generally lean towards a stricter schema and remove
  restrictions as it becomes necessary.
- rename `currency_listings` to `currencies_listings`. This seems to be
  the most common convention for naming join tables. Join the table
  names in alphabetical order. So a join table between `currencies` and
  `listings` becomes `currencies_listings`.