### PR TITLE
Rubocop: enable Rails rules

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,14 +12,6 @@ Metrics/MethodLength:
   Max: 14
 
 # Offense count: 1
-Rails/FilePath:
-  Exclude:
-    - 'config/environments/development.rb'
-
-Rails/InverseOf:
-  Enabled: false
-
-# Offense count: 1
 # Cop supports --auto-correct.
 Style/BlockComments:
   Exclude:

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -5,5 +5,5 @@ class Listing < ApplicationRecord
 
   has_many :currencies_listings
   has_many :currencies, through: :currencies_listings
-  belongs_to :submitter, class_name: :User # , inverse_of: :user
+  belongs_to :submitter, class_name: :User, inverse_of: :submissions
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 class User < ApplicationRecord
   validates :display_name, :email, :password_digest, presence: true
   validates :display_name, :email, uniqueness: true
-  has_many :submissions, class_name: :Listing, foreign_key: :submitter_id # inverse_of: :listing
 
+  has_many :submissions, class_name: :Listing, foreign_key: :submitter_id, inverse_of: :submitter
   has_secure_password
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store


### PR DESCRIPTION
- `Rails/FilePath` requires comma separated path sections. This is
  ostensibly for portability so that these commands can run on Windows
  systems, since they use `\` instead of `/` for folder delimiters.
  Practically speaking, there may never be a case for running this app
  on Windows, so my argument in favor of enabling this rule is simply
  that it enforces consistency.
- `Rails/InverseOf` requires that we specify an `inverse_of` on custom
  model relations.