### PR TITLE
Rubocop: enable BlockComments rule & RSpec options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 /yarn-error.log
 
 .byebug_history
+
+/spec/examples.txt

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,12 +11,6 @@
 Metrics/MethodLength:
   Max: 14
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/BlockComments:
-  Exclude:
-    - 'spec/spec_helper.rb'
-
 # Offense count: 32
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe ListingsController do
+RSpec.describe ListingsController do
   let!(:satoshi) { User.create(display_name: 'satoshi', email: 'satoshi@bitcoin.org', password_digest: '123456') }
   let!(:listing) { Listing.create(name: 'Pizza House', submitter_id: satoshi.id) }
 

--- a/spec/models/listings_spec.rb
+++ b/spec/models/listings_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Listing do
+RSpec.describe Listing do
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:submitter_id) }
   it { is_expected.to have_many(:currencies) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,9 +47,6 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -60,7 +57,7 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.example_status_persistence_file_path = 'spec/examples.txt'
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
@@ -76,7 +73,7 @@ RSpec.configure do |config|
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
+    config.default_formatter = 'doc'
   end
 
   # Print the 10 slowest examples and example groups at the
@@ -95,5 +92,4 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-=end
 end


### PR DESCRIPTION
Looks like this rule prohibits `=begin`/`=end` style block comments. We
just had the one in our `spec_helper.rb` file, so I removed it, enabling
a bunch of suggested RSpec options. These include:

- enabling `:focus` behavior. We can add a `:focus` option after a spec
  description and RSpec will run only that spec. Convenient for
  debugging and development.
- enabling failure tracking. RSpec will write spec results out to a
  `spec/examples.txt` file so that you can run only failed specs again.
- `disable_monkey_patching!` removes various monkey patches that RSpec
  has historically done. Most relevant to us is that it doesn't add the
  global function `describe` at the top level, so we need to instead
  call `RSpec.describe`.
- A couple of other niceties.