### PR TITLE
CircleCI: bring back TEST_FILES

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,9 @@ jobs:
 
             bundle exec rspec --format progress \
                             --format RspecJunitFormatter \
-                            --out /tmp/test-results/rspec.xml
+                            --out /tmp/test-results/rspec.xml \
+                            $TEST_FILES
       - run: bundle exec rubocop
-
 
       # collect reports
       - store_test_results:


### PR DESCRIPTION
We removed this in our attempts to get CircleCI working. Now that we've
got it working we should be able to bring it back.