### PR TITLE
Re-enable Metrics/AbcSize rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,5 +21,4 @@ Style/SafeNavigation: { Enabled: false }
 # Things I'm not prepared to deal with at the moment. Feel free to refactor.
 Metrics/AbcSize:
   Exclude:
-    - '**/listings_controller.rb'
     - '**/app/models/listing.rb'

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -14,7 +14,7 @@ class ListingsController < ApplicationController
   end
 
   def create
-    @listing = Listing.new(listing_params.merge(submitter_id: current_user.id))
+    @listing = Listing.new(listing_params)
 
     if @listing.save
       @listing.currencies = Currency.where(id: params[:currencies])
@@ -41,7 +41,7 @@ class ListingsController < ApplicationController
 
   def update
     @listing = Listing.find(params[:id])
-    @listing.update_attributes(listing_params)
+    @listing.update!(listing_params)
     update_currencies
     redirect_to listings_path
   end
@@ -58,11 +58,13 @@ class ListingsController < ApplicationController
     country
     phone
     url
-    submitter_id
   ].freeze
 
   def listing_params
-    params.require(:listing).permit(*PERMITTED_PARAMS)
+    params
+      .require(:listing)
+      .permit(*PERMITTED_PARAMS)
+      .merge(submitter_id: current_user.id)
   end
 
   def update_currencies

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,6 +29,8 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,6 +25,8 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -47,13 +47,12 @@ RSpec.describe ListingsController do
   describe 'POST #create' do
     let(:bitcoin) { create(:currency) }
     let(:currency_params) { [bitcoin.id] }
-    let(:listing_params)  { { name: 'Pub Satoshi', submitter_id: satoshi.id } }
+    let(:valid_params) { { listing: { name: 'Pub Satoshi' } } }
 
     context 'when a user is logged in' do
       before do
         login(satoshi)
-        post :create, params: { listing: listing_params,
-                                currencies: currency_params }
+        post :create, params: valid_params.merge(currencies: currency_params)
       end
 
       it 'adds a listing to the database' do
@@ -71,7 +70,7 @@ RSpec.describe ListingsController do
 
     context 'when a user is not logged in' do
       before do
-        post :create, params: { listing: listing_params }
+        post :create, params: valid_params
       end
 
       it 'adds a listing to the database' do


### PR DESCRIPTION
Minor refactors in `ListingsController` to account for this. I also
removed `submitter_id` from permitted params, since that's added in on
the server, and enabled errors being thrown when invalid params are
passed in development or test.