### PR TITLE
CircleCI: refactor deploy commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,6 @@ jobs:
           path: /tmp/test-results
           destination: test-results
 
-  # jobs for building/testing go here
   deploy-job:
     docker:
       - image: circleci/ruby:2.4.1-node-browsers
@@ -78,8 +77,7 @@ jobs:
       - checkout
       - run:
           name: Deploy Master to Heroku
-          command: |  # this command is framework-dependent and may vary
-            git push --force https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME.git HEAD:refs/heads/master
+          command: bash .circleci/heroku_deploy.sh
 
 workflows:
   version: 2

--- a/.circleci/heroku_deploy.sh
+++ b/.circleci/heroku_deploy.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eu
+
 wget https://cli-assets.heroku.com/branches/stable/heroku-linux-amd64.tar.gz
 sudo mkdir -p /usr/local/lib /usr/local/bin
 sudo tar -xvzf heroku-linux-amd64.tar.gz -C /usr/local/lib
@@ -14,3 +16,9 @@ cat >> ~/.ssh/config << EOF
 VerifyHostKeyDNS yes
 StrictHostKeyChecking no
 EOF
+
+heroku maintenance:on
+heroku git:remote -a $HEROKU_APP_NAME
+git push heroku master
+heroku run rake db:migrate
+heroku maintenance:off


### PR DESCRIPTION
- turn on maintenance mode while deploy is in progress to prevent
  migration errors and timeouts
- run migrations after deploying
- `set -eu` by default bash scripts continue to run even when an error
  is thrown. The `-e` part tells it to bail on the first error rather
  than snowballing into bigger issues. The `u` bit prevents using
  uninitialized variables.

https://circleci.com/docs/2.0/deployment-integrations/#heroku