### PR TITLE
CircleCI: try to fix deploy build

### DIFF
--- a/.circleci/heroku_deploy.sh
+++ b/.circleci/heroku_deploy.sh
@@ -17,8 +17,8 @@ VerifyHostKeyDNS yes
 StrictHostKeyChecking no
 EOF
 
-heroku maintenance:on
 heroku git:remote -a $HEROKU_APP_NAME
+heroku maintenance:on
 git push heroku master
 heroku run rake db:migrate
 heroku maintenance:off


### PR DESCRIPTION
It didn't work. Complained about not knowing which app to send to. I
think setting up the remote should fix it.

```
heroku/bin/heroku
 ▸    Error: No app specified
 ▸    Usage: heroku maintenance:on --app APP
 ▸    We don't know which app to run this on.
 ▸    Run this command from inside an app folder or specify which app to use with --app APP
```

https://circleci.com/gh/helios-coop/corner/205