### PR TITLE
Rubocop: swap array shorthand rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,10 +14,12 @@ Rails: { Enabled: true }
 Metrics/BlockLength: { Exclude: [spec/**/*_spec.rb] }
 Metrics/MethodLength: { Exclude: [db/migrate/**] }
 Rails/HasManyOrHasOneDependent: { Enabled: false }
-Rspec/MultipleExpectations: { Enabled: false }
+RSpec/MultipleExpectations: { Enabled: false }
 Style/Documentation: { Enabled: false }
 Style/MixinUsage: { Exclude: [bin/**] }
 Style/SafeNavigation: { Enabled: false }
+Style/SymbolArray: { EnforcedStyle: brackets }
+Style/WordArray: { EnforcedStyle: brackets }
 
 Layout/EmptyLinesAroundArguments:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'puma' # Use Puma as the app server
 gem 'sass-rails' # Use SCSS for stylesheets
 gem 'sidekiq'
 gem 'turbolinks' # Makes navigating your web application faster
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby] # Windows zoneinfo
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby] # for Windows
 gem 'uglifier' # Use Uglifier as compressor for JavaScript assets
 
 # gem 'redis', '~> 4.0' # Use Redis adapter to run Action Cable in production

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ListingsController < ApplicationController
-  before_action :authorize, except: %i[index show]
+  before_action :authorize, except: [:index, :show]
 
   def index
     set_listings_and_coordinates
@@ -54,19 +54,19 @@ class ListingsController < ApplicationController
 
   private
 
-  PERMITTED_PARAMS = %i[
-    name
-    address
-    address2
-    city
-    state
-    zipcode
-    country
-    phone
-    url
-    lat
-    long
-    thumbnail_url
+  PERMITTED_PARAMS = [
+    :address,
+    :address2,
+    :city,
+    :country,
+    :lat,
+    :long,
+    :name,
+    :phone,
+    :state,
+    :thumbnail_url,
+    :url,
+    :zipcode
   ].freeze
 
   def listing_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,11 +19,11 @@ class UsersController < ApplicationController
 
   private
 
-  PERMITTED_PARAMS = %i[
-    display_name
-    email
-    password
-    password_confirmation
+  PERMITTED_PARAMS = [
+    :display_name,
+    :email,
+    :password,
+    :password_confirmation
   ].freeze
 
   def user_params

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,4 +13,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile += %w[listings.css]
+Rails.application.config.assets.precompile += ['listings.css']

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-%w[
-  .ruby-version
-  .rbenv-vars
-  tmp/restart.txt
-  tmp/caching-dev.txt
+[
+  '.ruby-version',
+  '.rbenv-vars',
+  'tmp/restart.txt',
+  'tmp/caching-dev.txt'
 ].each { |path| Spring.watch(path) }

--- a/db/migrate/20180305010835_add_constraints.rb
+++ b/db/migrate/20180305010835_add_constraints.rb
@@ -2,7 +2,7 @@
 
 class AddConstraints < ActiveRecord::Migration[5.1]
   def change
-    add_index :currency_listings, %i[currency_id listing_id], unique: true
+    add_index :currency_listings, [:currency_id, :listing_id], unique: true
     change_column_null :currencies, :name, false
     change_column_null :currencies, :symbol, false
     change_column_null :currency_listings, :currency_id, false

--- a/db/migrate/20180317164008_change_currencies_listings_index.rb
+++ b/db/migrate/20180317164008_change_currencies_listings_index.rb
@@ -3,10 +3,10 @@
 class ChangeCurrenciesListingsIndex < ActiveRecord::Migration[5.1]
   def change
     remove_index :currencies_listings,
-                 %i[currency_id listing_id]
+                 [:currency_id, :listing_id]
 
     add_index :currencies_listings,
-              %i[currency_id listing_id],
+              [:currency_id, :listing_id],
               where: 'deleted_at IS NULL',
               unique: true
   end

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ListingsController do
     end
 
     it 'updates currencies' do
-      expect(listing.reload.currencies.pluck(:name)).to match_array %w[Litecoin Tron]
+      expect(listing.reload.currencies.pluck(:name)).to match_array ['Litecoin', 'Tron']
     end
 
     it 'soft deletes removed currencies' do


### PR DESCRIPTION
We discussed this and even though the shorthand is nice, we decided this
is more consistent and less to remember. If some arrays are one format
and others are another it's an extra brain cycle to parse the
difference.