### PR TITLE
Tools: un-ignore `.env` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@
 
 /spec/examples.txt
 /coverage
-.env
+.env.local


### PR DESCRIPTION
Rather than ignore `.env` from git, we can use `.env.local` for super
secret local stuff, and `.env` for not so super secret local stuff which
I anticipate having a couple of things for soon.  Anything in
`.env.local` will override what's in `.env. `dotenv-rails` looks for a
number of different files.

https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use