### PR TITLE
Specs: remove currencies from factory

### DIFF
--- a/spec/factories/currencies.rb
+++ b/spec/factories/currencies.rb
@@ -1,16 +1,8 @@
 # frozen_string_literal: true
 
-CURRENCIES = [
-  { name: "Bitcoin", symbol: "BTC" },
-  { name: "Litecoin", symbol: "LTC" },
-  { name: "Bitcoin Cash", symbol: "BCH" },
-  { name: "Etherium", symbol: "ETH" },
-  { name: "Tron", symbol: "TRX" },
-].freeze
-
 FactoryBot.define do
   factory :currency do
-    sequence(:name) { |n| CURRENCIES[n][:name] }
-    sequence(:symbol) { |n| CURRENCIES[n][:symbol] }
+    name "Bitcoin"
+    symbol "BTC"
   end
 end


### PR DESCRIPTION
I didn't actually mean to check this in. Fixtures supercedes it.