### PR TITLE
Tools: add Procfile.dev

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bundle exec rails s -p 3000
+worker: bundle exec sidekiq


### PR DESCRIPTION
`Procfile` is basically a listing of processes that need to be booted to
run an app. Heroku uses this to run different dynos, and locally it can
be used with the `foreman` gem, `foreman start` to use `Procfile` by
default or `foreman start -f Procfile.dev` to use `Procfile.dev`. It's
likely we'll end up wanting slightly different configurations for dev
mode than for production, so it can be handy to have a separate one.
Right now I've changed the `web` command to use `rails s` instead of the
default puma config, since it provides better logging. Down the road we
may want to configure background workers differently on dev, introduce
`mailcatcher` to view emails in dev mode, and run `webpack-dev-server`
for assets.