### PR TITLE
Errors: return early when no google place

### DIFF
--- a/app/views/listings/_carousel.html.haml
+++ b/app/views/listings/_carousel.html.haml
@@ -1,3 +1,5 @@
+- return unless @google_place
+
 .carousel-inner
   .carousel-item.active
     - if image_url = Rails.cache.read("#{@google_place.id}-photo-0}")


### PR DESCRIPTION
This throws an error by default when no google place is present. Not
sure if this is the best way to resolve it, but it's a start.