### PR TITLE
Refactors: pull `ENV` access into helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 /spec/examples.txt
 /coverage
 .env.local
+.env.test.local

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,9 @@ git_source(:github) do |repo_name|
 end
 
 ruby "2.4.1"
+
+# needs to be included before any other gems that use environment variables
+gem "dotenv-rails", groups: [:development, :test]
 gem "rails", "~> 5.1.5"
 
 # https://github.com/ActsAsParanoid/acts_as_paranoid/issues/36
@@ -37,7 +40,6 @@ gem "uglifier" # Use Uglifier as compressor for JavaScript assets
 
 group :development, :test do
   gem "capybara" # Adds support for Capybara system testing and selenium driver
-  gem "dotenv-rails" # Move to the top if you need Env Vars before rails loads.
   gem "factory_bot_rails"
   gem "faker"
   gem "foreman"

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ For code quality purposes, we use [Rubocop](https://github.com/bbatsov/rubocop).
 We use two files for Environment Variables.
 The `.env` file is included in the repo and has public env vars.
 
-Create another file name `.env.local` to hold secret env vars.
+Create files named `.env.local` and `.env.test.local` to hold secret env vars.
 In the `.env` file look at the section titled: **Secret Environment Variables**.
 
-Copy the key value pairs to `.env.local`. Then find someone on the team to share
-the values with you.
+Copy the key value pairs to `.env.local` and `.env.test.local`. Then find
+someone on the team to share the values with you.
 
 ---
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   helper_method :current_user
+  helper_method :google_maps_api_key
 
   before_action :detect_device_variant
 
@@ -31,5 +32,9 @@ class ApplicationController < ActionController::Base
     return unless browser.device.mobile?
     request.variant = :phone
     prepend_view_path Rails.root + "app" + "views" + "mobile_views"
+  end
+
+  def google_maps_api_key
+    ENV.fetch("GOOGLE_MAPS_API_KEY")
   end
 end

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -130,7 +130,7 @@ class ListingsController < ApplicationController
 
   def create_google_place_variables(google_place_id)
     return if Rails.env.test?
-    @google_places_client = GooglePlaces::Client.new(ENV["GOOGLE_MAPS_API_KEY"])
+    @google_places_client = GooglePlaces::Client.new(google_maps_api_key)
     @google_place = @google_places_client.spot(google_place_id)
     @reviews = @google_place.reviews.first(5)
   end

--- a/app/views/listings/index.html.haml
+++ b/app/views/listings/index.html.haml
@@ -86,4 +86,4 @@
 
 
 -# This has to be called after javascript above loads
-%script{:async => "", :defer => "defer", :src => "https://maps.googleapis.com/maps/api/js?key=#{ENV["GOOGLE_MAPS_API_KEY"]}&callback=initMap"}
+%script{:async => "", :defer => "defer", :src => "https://maps.googleapis.com/maps/api/js?key=#{google_maps_api_key}&callback=initMap"}

--- a/app/views/listings/new.html.haml
+++ b/app/views/listings/new.html.haml
@@ -2,7 +2,7 @@
 
 = content_for :head do
   = stylesheet_link_tag 'listings'
-  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{ENV["GOOGLE_MAPS_API_KEY"]}&libraries=places", 'data-turbolinks-track': 'reload'
+  = javascript_include_tag "https://maps.googleapis.com/maps/api/js?key=#{google_maps_api_key}&libraries=places", 'data-turbolinks-track': 'reload'
 
 #listings-new-form
   .container-fluid

--- a/app/views/mobile_views/listings/index.html.haml
+++ b/app/views/mobile_views/listings/index.html.haml
@@ -89,4 +89,4 @@
 
 
 -# This has to be called after javascript above loads
-%script{:async => "", :defer => "defer", :src => "https://maps.googleapis.com/maps/api/js?key=#{ENV["GOOGLE_MAPS_API_KEY"]}&callback=initMap"}
+%script{:async => "", :defer => "defer", :src => "https://maps.googleapis.com/maps/api/js?key=#{google_maps_api_key}&callback=initMap"}

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -6,6 +6,6 @@ Geocoder.configure(
   ip_lookup: :freegeoip,
   language: :en,
   use_https: false,
-  api_key: ENV["GOOGLE_MAPS_API_KEY"],
+  api_key: ENV.fetch("GOOGLE_MAPS_API_KEY"),
   units: :mi,
 )


### PR DESCRIPTION
Rather than accessing `ENV["GOOGLE_MAPS_API_KEY"]` in different places
this pulls it up into a helper method in `application_controller.rb`.
This way fewer places need to know where the information is coming from.
It can make things easier to test potentially by stubbing the value, and
avoids a global mystery guest, instead using a method call.

I also switched to using `.fetch`, which will throw an error if the key
is not found. This can help reduce head scratching as to why the app
isn't doing what we think it should. Because of this, we'll also need a
`.env.test.local` file, as `.env.local` does not get loaded in test
mode.