### PR TITLE
Refactors: cache carousel on listing

### DIFF
--- a/app/views/listings/_carousel.html.haml
+++ b/app/views/listings/_carousel.html.haml
@@ -1,17 +1,10 @@
-.carousel-inner
-  .carousel-item.active
-    - if image_url = Rails.cache.read("#{@google_place.id}-photo-0}")
-      %img.d-block.w-100{:alt => "First slide", :src => image_url}
-    - else
-      - image_url = @google_place.photos[0].fetch_url(400)
-      - Rails.cache.write("#{@google_place.id}-photo-0}", image_url)
+- cache @listing do
+  .carousel-inner
+    .carousel-item.active
+      - image_url = @google_place.photos.first.fetch_url(400)
       %img.d-block.w-100{:alt => "First slide", :src => image_url}
 
-  - 1.upto(@google_place.photos.count - 1) do |index|
-    .carousel-item
-      - if image_url = Rails.cache.read("#{@google_place.id}-photo-#{index}}")
-        %img.d-block.w-100{:alt => "First slide", :src => image_url}
-      - else
-        - image_url = @google_place.photos[index].fetch_url(400)
-        - Rails.cache.write("#{@google_place.id}-photo-#{index}}", image_url)
+    - @google_place.photos.drop(1).each do |photo|
+      .carousel-item
+        - image_url = photo.fetch_url(400)
         %img.d-block.w-100{:alt => "First slide", :src => image_url}


### PR DESCRIPTION
Rather than caching each individual image, this caches all of the images
under the listing. If we want to re-fetch the images we can simply
`touch` the listing to invalidate the cache key.

We might want to reconsider this caching at some point, since it only
works for this particular template. If we end up wanting to re-use the
images in another place, we can probably find a way to cache inside the
model instead.