### PR TITLE
Rubocop: get line length down in listings_spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,5 +47,4 @@ Metrics/BlockLength:
 Metrics/LineLength:
   Exclude:
     - '**/spec/controllers/listings_controller_spec.rb'
-    - '**/spec/models/listings_spec.rb'
     - '**/app/controllers/listings_controller.rb'

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -2,7 +2,9 @@
 
 class Listing < ApplicationRecord
   validates :name, :submitter_id, presence: true
-  validates :google_places_id, uniqueness: true, allow_nil: true
+  validates :google_places_id,
+            uniqueness: { case_sensitive: false },
+            allow_nil: true
 
   has_many :currencies_listings
   has_many :currencies, through: :currencies_listings

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe UsersController, type: :controller do
-  let(:user_params) { attributes_for(:user) }
+  let(:user_params) { attributes_for(:user).without(:role) }
 
   describe "GET #new" do
     before { get :new }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     email { Faker::Internet.email }
     password "blahblah"
     password_confirmation "blahblah"
+    role "user"
   end
 end

--- a/spec/models/listings_spec.rb
+++ b/spec/models/listings_spec.rb
@@ -9,10 +9,12 @@ RSpec.describe Listing do
   it { is_expected.to belong_to(:submitter) }
 
   describe "uniqueness" do
-    subject { described_class.new(name: "Satoshi Cafe", submitter_id: satoshi.id, google_places_id: "12345") }
+    before { create(:listing, google_places_id: "abc123") }
 
     let(:satoshi) { users(:satoshi) }
 
-    it { is_expected.to validate_uniqueness_of(:google_places_id).case_insensitive }
+    it do
+      is_expected.to validate_uniqueness_of(:google_places_id).case_insensitive
+    end
   end
 end


### PR DESCRIPTION
This also required adding `role` to the user factory, and it turns out
we weren't actually validating case insensitivity because the
`google_places_id` used in the test didn't have any letters, so fixed
that.