### PR TITLE
Gems: remove tzinfo gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ gem "puma" # Use Puma as the app server
 gem "sass-rails" # Use SCSS for stylesheets
 gem "sidekiq"
 gem "turbolinks" # Makes navigating your web application faster
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby] # for Windows
 gem "uglifier" # Use Uglifier as compressor for JavaScript assets
 
 # gem 'redis', '~> 4.0' # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -378,7 +378,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks
-  tzinfo-data
   uglifier
   web-console (>= 3.3.0)
 


### PR DESCRIPTION
If people want to work on windows, we may want to look into
Docker/Vagrant to maintain a consistent environment.