### PR TITLE
Specs: remove require for capybara/rails

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,7 +15,6 @@ if Rails.env.production?
 end
 require "rspec/rails"
 require "support/auth_helpers"
-require "capybara/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
Apparently we don't need that...