### PR TITLE
Upgrades: replace acts_as_paranoid with paranoia

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,6 @@ ruby "2.4.1"
 gem "dotenv-rails", groups: [:development, :test]
 gem "rails", "~> 5.1.5"
 
-# https://github.com/ActsAsParanoid/acts_as_paranoid/issues/36
-gem "acts_as_paranoid", github: "ActsAsParanoid/acts_as_paranoid"
 gem "bcrypt" # Use ActiveModel has_secure_password
 gem "bootstrap"
 gem "browser"
@@ -27,6 +25,7 @@ gem "haml-rails"
 gem "honeybadger"
 gem "jbuilder" # Build JSON APIs with ease
 gem "jquery-rails"
+gem "paranoia"
 gem "pg"
 gem "pg_search"
 gem "puma" # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/ActsAsParanoid/acts_as_paranoid.git
-  revision: d643738e1373850d4225d4678a129ef4e648e719
-  specs:
-    acts_as_paranoid (1.0.0.beta)
-      activerecord (>= 4.2, < 6.0)
-      activesupport (>= 4.2, < 6.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -179,6 +171,8 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     parallel (1.12.1)
+    paranoia (2.4.1)
+      activerecord (>= 4.0, < 5.3)
     parser (2.5.1.0)
       ast (~> 2.4.0)
     pg (1.0.0)
@@ -342,7 +336,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  acts_as_paranoid!
   bcrypt
   bootstrap
   browser
@@ -365,6 +358,7 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  paranoia
   pg
   pg_search
   pry-byebug

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -54,7 +54,7 @@ class ListingsController < ApplicationController
     @listing = Listing.find(params[:id])
     if @listing.editable_by?(current_user)
       @listing.update!(listing_params)
-      @listing.currencies = Currency.where(id: params[:currencies])
+      @listing.replace_currencies(Currency.where(id: params[:currencies]))
     else
       flash[:danger] = "Sorry, you cannot edit this listing"
     end

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -31,4 +31,11 @@ class Listing < ApplicationRecord
   def editable_by?(user)
     user == submitter || ["admin", "moderator"].include?(user.role)
   end
+
+  def replace_currencies(currencies)
+    new_currencies = currencies - self.currencies
+    removed_currencies = self.currencies - currencies
+    currencies_listings.where(currency_id: removed_currencies).destroy_all
+    self.currencies += new_currencies
+  end
 end


### PR DESCRIPTION
`acts_as_paranoid` doesn't seem to work too well with Rails 5.2 and the
most recent version is also busted on Rails 5.1. `paranoia` seems to be
a little better maintained, so swapping them out. Unfortunately,
`paranoia` doesn't override the deletion of join records, though, so we
need to manually swap them out, which is why I added
`replace_currencies` in `listing.rb`.

https://github.com/ActsAsParanoid/acts_as_paranoid/issues/88
https://github.com/ActsAsParanoid/acts_as_paranoid/issues/94
https://github.com/ActsAsParanoid/acts_as_paranoid/pull/96