### PR TITLE
Upgrades: introduce chromedriver-helper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,12 @@ jobs:
           name: install dependencies
           command: |
             bundle install --jobs=4 --retry=3 --path vendor/bundle
-
-      - run: sudo apt update && sudo apt install postgresql-client
+            sudo apt update
+            sudo apt install postgresql-client
+            curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            sudo dpkg -i google-chrome.deb
+            sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
+            rm google-chrome.deb
 
       - save_cache:
           paths:

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ end
 group :test do
   gem "capybara"
   gem "capybara-screenshot", require: false
+  gem "chromedriver-helper"
   gem "rspec_junit_formatter", require: false
   gem "selenium-webdriver"
   gem "shoulda-matchers", "~> 3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (8.3.0)
@@ -71,6 +73,9 @@ GEM
       launchy
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
@@ -143,6 +148,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.0.0)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -353,6 +359,7 @@ DEPENDENCIES
   browser
   capybara
   capybara-screenshot
+  chromedriver-helper
   dalli
   dotenv-rails
   factory_bot_rails

--- a/README.md
+++ b/README.md
@@ -83,39 +83,6 @@ and
 
 and then navigate to `localhost:3000`
 
----
-
-For feature tests you'll need the chromedriver.
-You can either install using homebrew or download the binary directly.
-
-**Homebrew**
-
-```sh
-brew tap caskroom/cask
-```
-
-then
-
-```sh
-brew cask install chromedriver
-```
-
-### OR
-
-**Downloading**
-
-Download it here:
-
-<https://sites.google.com/a/chromium.org/chromedriver/downloads>
-
-Unpack it and install it in any folder in your OS path
-
-To see your paths runs
-
-```sh
-echo $PATH
-```
-
 ## Data Model
 
 Keep this updated:


### PR DESCRIPTION
This makes it so that devs don't need to manually install `chromedriver`
and put it in their path somewhere. We might also consider the
`webdrivers` gem at some point if `geckodriver` becomes necessary.
`chromedriver-helper` is just bundled by default in new Rails apps so
figured I'd stick with that for now.

https://github.com/flavorjones/chromedriver-helper
https://github.com/titusfortner/webdrivers