### PR TITLE
Upgrades: remove version constraints for gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,10 +53,10 @@ group :development, :test do
 end
 
 group :development do
-  gem "listen", ">= 3.0.5", "< 3.2"
+  gem "listen"
   gem "spring" # Speeds up development by keeping your application running
-  gem "spring-watcher-listen", "~> 2.0.0"
-  gem "web-console", ">= 3.3.0" # Access an IRB console on exception pages
+  gem "spring-watcher-listen"
+  gem "web-console" # Access an IRB console on exception pages
 end
 
 group :test do
@@ -65,6 +65,6 @@ group :test do
   gem "chromedriver-helper"
   gem "rspec_junit_formatter", require: false
   gem "selenium-webdriver"
-  gem "shoulda-matchers", "~> 3.1"
+  gem "shoulda-matchers"
   gem "simplecov", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -376,7 +376,7 @@ DEPENDENCIES
   honeybadger
   jbuilder
   jquery-rails
-  listen (>= 3.0.5, < 3.2)
+  listen
   paranoia
   pg
   pg_search
@@ -391,14 +391,14 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails
   selenium-webdriver
-  shoulda-matchers (~> 3.1)
+  shoulda-matchers
   sidekiq
   simplecov
   spring
-  spring-watcher-listen (~> 2.0.0)
+  spring-watcher-listen
   turbolinks
   uglifier
-  web-console (>= 3.3.0)
+  web-console
 
 RUBY VERSION
    ruby 2.4.1p111


### PR DESCRIPTION
These don't need to be locked down in `Gemfile`, as they are locked in
`Gemfile.lock`. As a general philosophy, I don't like to lock things
down in `Gemfile` unless there is an issue of some sort preventing us
from upgrading a particular gem, in which case I'll often add an
explanatory comment or link to an issue on Github for reference.