### PR TITLE
CircleCI: try to fix build error on Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           command: |
             bundle install --jobs=4 --retry=3 --path vendor/bundle
             sudo apt update
-            sudo apt install postgresql-client
+            sudo apt install postgresql-client libappindicator3-1
             curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
             sudo dpkg -i google-chrome.deb
             sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome


### PR DESCRIPTION
The build failed, apparently for lack of some library
`libappindicator3-1`, so we'll try installing it.

https://circleci.com/gh/helios-coop/corner/641