### PR TITLE
Specs: remove ActionCable stuff

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module ApplicationCable
-  class Channel < ActionCable::Channel::Base
-  end
-end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module ApplicationCable
-  class Connection < ActionCable::Connection::Base
-  end
-end


### PR DESCRIPTION
Dunno if we'll ever need these, but they're easy to re-introduce if they
do become necessary. And they're keeping us from getting to 100% test
coverage!