### PR TITLE
Errors: remove es6 arrow function

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,7 +25,7 @@
 //= require_tree .
 
 // Enable google analytics with turbolinks
-document.addEventListener("turbolinks:load", event => {
+document.addEventListener("turbolinks:load", function (event) {
   if (typeof ga === "function") {
     ga("set", "location", event.data.url);
     ga("send", "pageview");


### PR DESCRIPTION
We don't have a js build pipeline right now, so can't use arrow
functions just yet.