### PR TITLE
Remove online only listings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,7 @@ Style/TrailingCommaInArguments: { EnforcedStyleForMultiline: consistent_comma }
 Style/TrailingCommaInArrayLiteral: { EnforcedStyleForMultiline: consistent_comma }
 Style/TrailingCommaInHashLiteral: { EnforcedStyleForMultiline: consistent_comma }
 Style/WordArray: { EnforcedStyle: brackets }
+Style/GuardClause: { MinBodyLength: 3 }
 
 # Things that can be improved
 Metrics/AbcSize:
@@ -47,3 +48,11 @@ Metrics/LineLength:
     - app/controllers/application_controller.rb
     - app/controllers/listings_controller.rb
     - db/migrate/**
+
+Metrics/CyclomaticComplexity:
+  Exclude:
+    - app/controllers/listings_controller.rb
+
+Metrics/PerceivedComplexity:
+  Exclude:
+    - app/controllers/listings_controller.rb

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -110,18 +110,21 @@ class ListingsController < ApplicationController
     search_terms[:name]     = params[:name]     if params[:name].present?
     search_terms[:location] = params[:location] if params[:location].present?
     search_terms[:category] = params[:category] if params[:category].present?
+
     if search_terms.present?
-      listings = Listing.full_search(search_terms)
+      @listings = Listing.full_search(search_terms)
     else
       set_map_center_point
       coordinates = gon.centerPoint.values_at(:latitude, :longitude)
-      listings = Listing.full_search(coordinates: coordinates)
+      @listings = Listing.full_search(coordinates: coordinates)
     end
 
-    gon.coordinates = listings.map(&:coordinates)
+    gon.coordinates = @listings.map(&:coordinates)
 
     # Until we have enough local listings add in online_only
-    @listings = (listings + Listing.where.not(online_only: nil)).uniq
+    if search_terms[:location].present? || search_terms.empty?
+      @listings = (@listings + Listing.where.not(online_only: nil)).uniq
+    end
   end
 
   def set_map_center_point


### PR DESCRIPTION
Remove the extra online-only listings when someone is searching by name or category. 
They are being used mostly for location searches so results don't look so empty. 
