### PR TITLE
Seeds: move category creation method to seeds

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ AllCops:
 Rails: { Enabled: true }
 
 Metrics/BlockLength: { Exclude: [config/**/*.rb, spec/**/*_spec.rb] }
+RSpec/DescribeClass: { Exclude: [spec/db/**/*] }
 RSpec/ExampleLength: { Enabled: false }
 RSpec/MultipleExpectations: { Enabled: false }
 Rails/HasManyOrHasOneDependent: { Enabled: false }

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -11,12 +11,4 @@ class Category < ApplicationRecord
   pg_search_scope :search_by_name,
                   against: :name,
                   using: { tsearch: { prefix: true } }
-
-  CATEGORY_NAMES = load_data("category_names")
-
-  def self.update_all_categories
-    CATEGORY_NAMES.each do |category_name|
-      Category.find_or_create_by(name: category_name)
-    end
-  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This file should contain all the record creation needed to seed the database
 # with its default values. The data can then be loaded with the rails db:seed
 # command (or created alongside the database with db:setup).
@@ -7,3 +8,12 @@
 #
 #  movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #  Character.create(name: 'Luke', movie: movies.first)
+
+def load_data(name)
+  YAML.safe_load(File.read(Rails.root.join("config/data/#{name}.yml"))).freeze
+end
+
+category_names = load_data("category_names")
+(category_names - Category.pluck(:name)).each do |category_name|
+  Category.create!(name: category_name)
+end

--- a/spec/db/seeds_spec.rb
+++ b/spec/db/seeds_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "seeds" do
+  def load_seeds
+    load Rails.root.join("db", "seeds.rb")
+  end
+
+  it "loads a whole bunch of categories into the database" do
+    expect do
+      load_seeds
+    end.to change(Category, :count).by(1311)
+
+    expect(Category.exists?(name: "not a category")).to be false
+    expect(Category.exists?(name: "Qi Gong")).to be true
+  end
+end


### PR DESCRIPTION
Now we can run `rake db:seed` to load this data. Not a big deal, but
there's an N+1 query here, so if we get around to integrating a bulk
import library such as `activerecord-import`, might be worth swapping in
here as well.

https://github.com/zdennis/activerecord-import