### PR TITLE
Seeds: add mock data for dev mode

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,16 @@
 require_relative "config/application"
 
 Rails.application.load_tasks
+
+namespace :db do
+  break if Rails.env.production?
+
+  desc "add demo data to the database"
+  task populate: :environment do
+    load "./db/mock_data.rb"
+  end
+
+  Rake::Task["db:reset"].enhance do
+    Rake::Task["db:populate"].invoke
+  end
+end

--- a/db/mock_data.rb
+++ b/db/mock_data.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+User.create!(
+  display_name: "Demo",
+  role: "user",
+  email: "demo@cornerpay.com",
+  password: "cornerpay",
+  password_confirmation: "cornerpay",
+)


### PR DESCRIPTION
We have `db/seeds.rb`, but I treat this as a file that can be run in
production, whereas we also want dev-only data, like a fake user to poke
around with. For this, I added a `db/mock_data.rb` file, and enhanced
the `rake db:reset` command to populate the database from this file. We
can also use `rake db:populate` to just add the records and nothing
else. I `break` early to prevent accidentally running this in
production.