### PR TITLE
haml-lint: enable ConsecutiveComments rule

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -70,13 +70,6 @@ linters:
       - "app/views/mobile_views/listings/_google_place_details.html.haml"
       - "app/views/mobile_views/listings/_non_google_place_details.html.haml"
 
-  # Offense count: 4
-  ConsecutiveComments:
-    exclude:
-      - "app/views/listings/_google_places_form.html.haml"
-      - "app/views/mobile_views/listings/show.js.haml"
-      - "app/views/sessions/new.html.haml"
-
   # Offense count: 3
   ViewLength:
     exclude:

--- a/app/views/listings/_google_places_form.html.haml
+++ b/app/views/listings/_google_places_form.html.haml
@@ -24,9 +24,6 @@
           = check_box_tag "currencies[]", currency.id,  @listing.currencies.include?(currency), id: currency.symbol
           %label{class: 'currency-check-box form-check-label', for:"#{currency.symbol}"}= currency.symbol
 
-          -# = check_box_tag "currencies[]", currency.id, @listing.currencies.include?(currency), id: currency.id
-          -# %label{ class:"form-check-label", for:"#{currency.id}"}=
-
         %hr
         .input-group.mb-5
           = label_tag "Add Categories"

--- a/app/views/listings/show.js.haml
+++ b/app/views/listings/show.js.haml
@@ -1,4 +1,3 @@
-
 -# Update details card
 - if @listing.google_places_id
   $("#listing-details").html("#{escape_javascript(render partial: 'google_place_details', locals: { listing: @listing } ) }");

--- a/app/views/mobile_views/listings/show.js.haml
+++ b/app/views/mobile_views/listings/show.js.haml
@@ -1,4 +1,3 @@
-
 -# Update details card
 - if @listing.google_places_id
   $("#mobile-listing-details").html("#{escape_javascript(render partial: 'google_place_details', locals: { listing: @listing } ) }");
@@ -17,5 +16,4 @@ googleMap.setCenter(newCenter);
 googleMap.setZoom(16)
 
 -# Update photos
--# TODO: Probably need to save photo urls when the listing is created. This seems slow
 $(".carousel-inner").html("#{escape_javascript(render partial: 'carousel') }");

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -6,15 +6,6 @@
     .col-5
       %h1 Log In
 
-
-      -# Error messages
-      -# - if @user.errors.any?
-      -#   .error_messages
-      -#     %h2 Form is invalid
-      -#     %ul
-      -#       - for message in @user.errors.full_messages
-      -#         %li{style: "color: red;"}= message
-
       = form_tag login_path do
         .form-group
           = label_tag :email


### PR DESCRIPTION
Just deleted comments. `TODO` comments should probably go into Trello,
and the code comments will be in the history, so easy to recover if we
decide we need them.

https://github.com/brigade/haml-lint/blob/master/lib/haml_lint/linter/README.md#consecutivecomments