### PR TITLE
haml-lint: enable UnnecessaryStringOutput rule

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -62,14 +62,6 @@ linters:
     exclude:
       - "app/views/listings/_form.html.haml"
 
-  # Offense count: 4
-  UnnecessaryStringOutput:
-    exclude:
-      - "app/views/listings/_google_place_details.html.haml"
-      - "app/views/listings/_non_google_place_details.html.haml"
-      - "app/views/mobile_views/listings/_google_place_details.html.haml"
-      - "app/views/mobile_views/listings/_non_google_place_details.html.haml"
-
   # Offense count: 3
   ViewLength:
     exclude:

--- a/app/views/listings/_google_place_details.html.haml
+++ b/app/views/listings/_google_place_details.html.haml
@@ -25,7 +25,7 @@
 
           %li
             = fa_icon "building"
-            = "#{@listing.address}, #{@listing.city}, #{@listing.state}"
+            #{@listing.address}, #{@listing.city}, #{@listing.state}
 
           %li
             = fa_icon "phone"

--- a/app/views/listings/_non_google_place_details.html.haml
+++ b/app/views/listings/_non_google_place_details.html.haml
@@ -13,7 +13,7 @@
               - if @listing.online_only
                 Online Only
               - else
-                = "#{@listing.address}, #{@listing.city}, #{@listing.state}"
+                #{@listing.address}, #{@listing.city}, #{@listing.state}
 
             %li
               = fa_icon "phone"

--- a/app/views/mobile_views/listings/_google_place_details.html.haml
+++ b/app/views/mobile_views/listings/_google_place_details.html.haml
@@ -25,7 +25,7 @@
 
           %li
             = fa_icon "building"
-            = "#{@listing.address}, #{@listing.city}, #{@listing.state}"
+            #{@listing.address}, #{@listing.city}, #{@listing.state}
 
       .col-12
         .show-details-button

--- a/app/views/mobile_views/listings/_non_google_place_details.html.haml
+++ b/app/views/mobile_views/listings/_non_google_place_details.html.haml
@@ -12,7 +12,7 @@
               - if @listing.online_only
                 Online Only
               - else
-                = "#{@listing.address}, #{@listing.city}, #{@listing.state}"
+                #{@listing.address}, #{@listing.city}, #{@listing.state}
 
             %li
               = fa_icon "phone"


### PR DESCRIPTION
Don't need quotes and whatnot here. We can do interpolation directly in
haml text.

https://github.com/brigade/haml-lint/blob/master/lib/haml_lint/linter/README.md#unnecessarystringoutput