### PR TITLE
haml-lint: enable ClassAttributeWithStaticValue rule

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -57,11 +57,6 @@ linters:
       - "app/views/mobile_views/listings/_google_place_details.html.haml"
       - "app/views/mobile_views/listings/_non_google_place_details.html.haml"
 
-  # Offense count: 2
-  ClassAttributeWithStaticValue:
-    exclude:
-      - "app/views/listings/_form.html.haml"
-
   # Offense count: 3
   ViewLength:
     exclude:

--- a/app/views/listings/_form.html.haml
+++ b/app/views/listings/_form.html.haml
@@ -13,7 +13,7 @@
         - @currencies.each do |currency|
           .form-check.form-check-inline
             = check_box_tag "currencies[]", currency.id, @listing.currencies.include?(currency), class: "form-check-input", id: currency.symbol
-            %label{ class:"form-check-label", for:"#{currency.symbol}"}= currency.symbol
+            %label.form-check-label{ for:"#{currency.symbol}"}= currency.symbol
 
     .row.form-group
       .col-sm-2 Phone
@@ -22,7 +22,7 @@
       .col-sm-2= f.label :url
       .col-sm-10= f.text_field :url, class: "form-control", :placeholder => "http://www.unchainedpodcast.co"
     .row.form-group
-      %label.col-sm-2{ class:"form-check-label", for:"online_only"} Online Only
+      %label.form-check-label.col-sm-2{ for:"online_only"} Online Only
       .col-sm-2= f.check_box :online_only, class: "form-check-input", id: "online_only"
     .form-row#address-components
       .form-group.col-sm-6


### PR DESCRIPTION
We only need to specify `class:` when we have some dynamic value.

https://github.com/brigade/haml-lint/blob/master/lib/haml_lint/linter/README.md#classattributewithstaticvalue