### PR TITLE
Validations: allow_nil for user password

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
 
   validates :display_name, :email, :password_digest, presence: true
   validates :display_name, :email, uniqueness: true
-  validates :password, length: { minimum: 8 }
+  validates :password, length: { minimum: 8 }, allow_nil: true
   validates :role, inclusion: { in: ROLES }
 
   has_many :submissions,


### PR DESCRIPTION
`password` is ephemeral on user, so it will be `nil` if you're updating
another attribute, and fail the validation. Now we only validate the
length if it's present, meaning, presumably, that it has been passed
from the client side.