### PR TITLE
Geocoder: enable ip location for dev/test mode

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # ---- Public Environment Variables ----
 
 AWS_REGION=us-west-1
-
+REMOTE_ADDR=208.67.222.222 # for geocoding
 
 # ---- Secret Environment Variables ----
 # These live in .env.local

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,10 +6,15 @@ class ApplicationController < ActionController::Base
   helper_method :current_user
   helper_method :google_maps_api_key
 
+  before_action :fake_ip unless Rails.env.production?
   before_action :detect_device_variant
   before_action :set_google_analytics_key if Rails.env.production?
 
   private
+
+  def fake_ip
+    request.headers["REMOTE_ADDR"] = ENV.fetch("REMOTE_ADDR")
+  end
 
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]

--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -146,14 +146,10 @@ class ListingsController < ApplicationController
   end
 
   def center_point_from_ip_address
-    if Rails.env.production?
-      {
-        latitude: request.location.data["latitude"],
-        longitude: request.location.data["longitude"],
-        zoom: 13,
-      }
-    else
-      { latitude: 37.791139, longitude: -122.396067, zoom: 9 }
-    end
+    {
+      latitude: request.location.data["latitude"],
+      longitude: request.location.data["longitude"],
+      zoom: 13,
+    }
   end
 end

--- a/spec/support/geocoder.rb
+++ b/spec/support/geocoder.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+Geocoder.configure(lookup: :test, ip_lookup: :test)
+
+Geocoder::Lookup::Test.set_default_stub(
+  [
+    {
+      "latitude"  => 37.791139,
+      "longitude" => -122.396067,
+      "address" => "Oakland, CA, USA",
+      "state" => "California",
+      "state_code" => "CA",
+      "country" => "United States",
+      "country_code" => "US",
+    },
+  ],
+)


### PR DESCRIPTION
This adds a method in `ApplicationController` to fake `REMOTE_ADDR` for
geocoding based on IP address. The default IP is in San Francisco. If we
want to override it, we can do so with `REMOTE_ADDR=1.1.1.1 rails s` or
by adding it in `.env.local`.

Side note, according to the docs, `request.location` is slow due to it
hitting a 3rd party API, so we'll probably want to find a way to
background it at some point.

https://github.com/alexreisner/geocoder#geocoding-is-slow