### PR TITLE
haml-lint: enable IdNames rule

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -22,14 +22,6 @@ linters:
       - "app/views/admin/currencies/_form.html.haml"
       - "app/views/users/new.html.haml"
 
-  # Offense count: 4
-  IdNames:
-    exclude:
-      - "app/views/layouts/_header.html.haml"
-      - "app/views/listings/index.html.haml"
-      - "app/views/mobile_views/layouts/_header.html.haml"
-      - "app/views/mobile_views/listings/index.html.haml"
-
   # Offense count: 10
   ClassesBeforeIds:
     exclude:

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -3,10 +3,10 @@
     = image_tag "corner_logo.png", height: 70
     = image_tag "beta-icon.png", height: 50
 
-  %button.navbar-toggler{ "aria-controls" => "navbarNav", "aria-expanded" => "false", "aria-label" => "Toggle navigation", "data-target" => "#navbarNav", "data-toggle" => "collapse", :type => "button" }
+  %button.navbar-toggler{ "aria-controls" => "navbar-nav", "aria-expanded" => "false", "aria-label" => "Toggle navigation", "data-target" => "#navbar-nav", "data-toggle" => "collapse", :type => "button" }
     %span.navbar-toggler-icon
 
-  #navbarNav.collapse.navbar-collapse.justify-content-end
+  #navbar-nav.collapse.navbar-collapse.justify-content-end
     - if current_page?(listings_path) || current_page?(root_path)
       #search= render "layouts/search"
 

--- a/app/views/listings/index.html.haml
+++ b/app/views/listings/index.html.haml
@@ -42,13 +42,13 @@
         #map
 
         #photos
-          #carouselControls.carousel.slide{ "data-ride" => "carousel" }
+          #carousel-controls.carousel.slide{ "data-ride" => "carousel" }
             = render "listings/carousel"
 
-            %a.carousel-control-prev{ "data-slide" => "prev", :href => "#carouselControls", :role => "button" }
+            %a.carousel-control-prev{ "data-slide" => "prev", :href => "#carousel-controls", :role => "button" }
               %span.carousel-control-prev-icon{ "aria-hidden" => "true" }
               %span.sr-only Previous
-            %a.carousel-control-next{ "data-slide" => "next", :href => "#carouselControls", :role => "button" }
+            %a.carousel-control-next{ "data-slide" => "next", :href => "#carousel-controls", :role => "button" }
               %span.carousel-control-next-icon{ "aria-hidden" => "true" }
               %span.sr-only Next
 

--- a/app/views/mobile_views/layouts/_header.html.haml
+++ b/app/views/mobile_views/layouts/_header.html.haml
@@ -3,10 +3,10 @@
     = image_tag "corner_logo.png", height: 70
     = image_tag "beta-icon.png", height: 50
 
-  %button.navbar-toggler{ "aria-controls" => "navbarNav", "aria-expanded" => "false", "aria-label" => "Toggle navigation", "data-target" => "#navbarNav", "data-toggle" => "collapse", :type => "button" }
+  %button.navbar-toggler{ "aria-controls" => "navbar-nav", "aria-expanded" => "false", "aria-label" => "Toggle navigation", "data-target" => "#navbar-nav", "data-toggle" => "collapse", :type => "button" }
     %span.navbar-toggler-icon
 
-  #navbarNav.collapse.navbar-collapse.justify-content-end
+  #navbar-nav.collapse.navbar-collapse.justify-content-end
     %ul.navbar-nav.nav-pills.ml-auto
       %li.nav-item.mr-1{ class: request.path == "/listings/new" ? "active" : "" }
         = link_to "Add Listing", new_listing_path, class: "nav-link"

--- a/app/views/mobile_views/listings/index.html.haml
+++ b/app/views/mobile_views/listings/index.html.haml
@@ -57,12 +57,12 @@
     .col#map-photos
     -# - if @google_place
     .card#photo-card
-      #carouselControls.carousel.slide{ "data-ride" => "carousel" }
+      #carousel-controls.carousel.slide{ "data-ride" => "carousel" }
         = render "listings/carousel"
-        %a.carousel-control-prev{ "data-slide" => "prev", :href => "#carouselControls", :role => "button" }
+        %a.carousel-control-prev{ "data-slide" => "prev", :href => "#carousel-controls", :role => "button" }
           %span.carousel-control-prev-icon{ "aria-hidden" => "true" }
           %span.sr-only Previous
-        %a.carousel-control-next{ "data-slide" => "next", :href => "#carouselControls", :role => "button" }
+        %a.carousel-control-next{ "data-slide" => "next", :href => "#carousel-controls", :role => "button" }
           %span.carousel-control-next-icon{ "aria-hidden" => "true" }
           %span.sr-only Next
 


### PR DESCRIPTION
This requires that html ids be in "lisp case" (or "kebab case").

https://github.com/brigade/haml-lint/blob/master/lib/haml_lint/linter/README.md#idnames