### PR TITLE
haml-lint: temporarily disable rubocop rules

### DIFF
--- a/.haml-lint_todo.yml
+++ b/.haml-lint_todo.yml
@@ -8,10 +8,6 @@
 
 linters:
 
-  # Offense count: 174
-  RuboCop:
-    enabled: false
-
   # Offense count: 105
   LineLength:
     enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,3 +56,18 @@ Metrics/CyclomaticComplexity:
 Metrics/PerceivedComplexity:
   Exclude:
     - app/controllers/listings_controller.rb
+
+Layout/ExtraSpacing: { Enabled: false }
+Layout/SpaceAfterColon: { Enabled: false }
+Layout/SpaceAfterComma: { Enabled: false }
+Layout/SpaceBeforeFirstArg: { Enabled: false }
+Layout/SpaceInsideParens: { Enabled: false }
+Layout/SpaceInsideStringInterpolation: { Enabled: false }
+Style/BracesAroundHashParameters: { Enabled: false }
+Style/For: { Enabled: false }
+Style/HashSyntax: { Enabled: false }
+Style/IdenticalConditionalBranches: { Enabled: false }
+Style/NestedParenthesizedCalls: { Enabled: false }
+Style/StringLiterals: { Enabled: false }
+Style/StringLiteralsInInterpolation: { Enabled: false }
+Style/UnneededInterpolation: { Enabled: false }


### PR DESCRIPTION
There are a bunch of violations, so going to tackle these a few at a
time.