### PR TITLE
Scroll to top

### DIFF
--- a/app/views/listings/show.js.haml
+++ b/app/views/listings/show.js.haml
@@ -17,3 +17,6 @@ googleMap.setZoom(16)
 
 -# Update photos
 $(".carousel-inner").html("#{escape_javascript(render(partial: "carousel"))}");
+
+-# Scroll to top of page
+$("html, body").animate({ scrollTop: 0 }, "fast");

--- a/app/views/mobile_views/listings/show.js.haml
+++ b/app/views/mobile_views/listings/show.js.haml
@@ -17,3 +17,6 @@ googleMap.setZoom(16)
 
 -# Update photos
 $(".carousel-inner").html("#{escape_javascript(render(partial: "carousel"))}");
+
+-# Scroll to top of page
+$("html, body").animate({ scrollTop: 0 }, "fast");


### PR DESCRIPTION
If a user is on the bottom of the page and clicks on a listing it doesn't seem like anything has happened. Better to scroll them to the top of the page. 