### PR TITLE
Views: switch to using currency_ids for params

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -25,7 +25,6 @@ class ListingsController < ApplicationController
     @listing = Listing.new(listing_attributes.merge(submitter: current_user))
 
     if @listing.save
-      @listing.currencies = Currency.where(id: params[:currencies])
       @listing.categories << Category.where(name: params[:categories])
 
       redirect_to listings_path
@@ -63,7 +62,6 @@ class ListingsController < ApplicationController
     @listing = Listing.find(params[:id])
     if @listing.editable_by?(current_user)
       @listing.update!(listing_params)
-      @listing.replace_currencies(Currency.where(id: params[:currencies]))
       @listing.categories = Category.where(name: params[:categories])
     else
       flash[:danger] = "Sorry, you cannot edit this listing"
@@ -87,6 +85,7 @@ class ListingsController < ApplicationController
     :url,
     :zipcode,
     :online_only,
+    currency_ids: [],
     images: [],
   ].freeze
 
@@ -96,7 +95,8 @@ class ListingsController < ApplicationController
 
   def listing_attributes_from_params
     if params[:from_google_places] == "true"
-      GooglePlaceParamsParser.new.call(params["google-place"])
+      place_params = GooglePlaceParamsParser.new.call(params["google-place"])
+      listing_params.merge(place_params)
     else
       listing_params
     end

--- a/app/models/currencies_listing.rb
+++ b/app/models/currencies_listing.rb
@@ -3,7 +3,7 @@
 class CurrenciesListing < ApplicationRecord
   acts_as_paranoid
 
-  validates :currency_id, :listing_id, presence: true
+  validates :currency_id, presence: true
 
   belongs_to :currency
   belongs_to :listing

--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -69,6 +69,10 @@ class Listing < ApplicationRecord
     user == submitter || ["admin", "moderator"].include?(user.role)
   end
 
+  def currency_ids=(currency_ids)
+    replace_currencies(Currency.find(currency_ids.select(&:present?)))
+  end
+
   def replace_currencies(currencies)
     new_currencies = currencies - self.currencies
     removed_currencies = self.currencies - currencies

--- a/app/views/listings/_form.html.haml
+++ b/app/views/listings/_form.html.haml
@@ -12,7 +12,11 @@
       .col-sm-10
         - @currencies.each do |currency|
           .form-check.form-check-inline
-            = check_box_tag "currencies[]", currency.id, @listing.currencies.include?(currency), class: "form-check-input", id: currency.symbol
+            = check_box_tag "listing[currency_ids][]",
+                            currency.id,
+                            @listing.currencies.include?(currency),
+                            class: "form-check-input",
+                            id: currency.symbol
             %label.form-check-label{ for: currency.symbol }= currency.symbol
 
     .row.form-group

--- a/app/views/listings/_google_places_form.html.haml
+++ b/app/views/listings/_google_places_form.html.haml
@@ -30,7 +30,7 @@
         = form_tag listings_path do
           %label#accepts Accepts:
           - @currencies.each do |currency|
-            = check_box_tag "currencies[]", currency.id, @listing.currencies.include?(currency), id: currency.symbol
+            = check_box_tag "listing[currency_ids][]", currency.id, @listing.currencies.include?(currency), id: currency.symbol
             %label{ class: "currency-check-box form-check-label", for: "#{currency.symbol}" }= currency.symbol
 
           %hr

--- a/spec/controllers/listings_controller_spec.rb
+++ b/spec/controllers/listings_controller_spec.rb
@@ -73,8 +73,7 @@ RSpec.describe ListingsController do
     let(:valid_params) do
       {
         id: listing.id,
-        currencies: [litecoin.id, tron.id],
-        listing: { name: "whatevs" },
+        listing: { name: "whatevs", currency_ids: [litecoin.id, tron.id] },
       }
     end
 
@@ -141,19 +140,20 @@ RSpec.describe ListingsController do
 
   describe "POST #create" do
     let(:bitcoin) { currencies(:bitcoin) }
-    let(:currency_params) { [bitcoin.id] }
     let(:google_place_params) do
       File.read(File.join(fixture_path, "places.json"))
     end
 
     let(:valid_params) do
-      { 'google-place': google_place_params, from_google_places: true }
+      {
+        'google-place': google_place_params,
+        from_google_places: true,
+        listing: { currency_ids: [bitcoin.id] },
+      }
     end
 
     context "when a user is logged in" do
-      subject(:post_request) do
-        post :create, params: valid_params.merge(currencies: currency_params)
-      end
+      subject(:post_request) { post :create, params: valid_params }
 
       before do
         login(satoshi)

--- a/spec/models/currencies_listing_spec.rb
+++ b/spec/models/currencies_listing_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe CurrenciesListing, type: :model do
   it { is_expected.to validate_presence_of(:currency_id) }
-  it { is_expected.to validate_presence_of(:listing_id) }
   it { is_expected.to belong_to(:currency) }
   it { is_expected.to belong_to(:listing) }
 end


### PR DESCRIPTION
Passes back `currency_ids` and nests them under the `listing` params. I
needed to disable the validation on `CurrenciesListing` because it
validates before the listing saves, so because the listing hasn't been
saved, yet, the id will not be present. It will, however, be present
when the `CurrenciesListing` record is auto-saved after the `Listing`.

This is angling towards using the `collection_check_boxes` form helper.

https://apidock.com/rails/v4.0.2/ActionView/Helpers/FormBuilder/collection_check_boxes