### PR TITLE
Storage: configure file storage to use local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+/storage
 
 /node_modules
 /yarn-error.log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,8 +34,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for
   # options)
-  # config.active_storage.service = :local
-  config.active_storage.service = :amazon_development
+  config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
This way there's one thing nobody has to have configured with AWS.