### PR TITLE
Views: only require images for new records

### DIFF
--- a/app/views/listings/_form.html.haml
+++ b/app/views/listings/_form.html.haml
@@ -46,7 +46,7 @@
     = label_tag "Add Images"
     .input-group.mb-1
       .custom-file
-        = f.file_field :images, multiple: true, id: "customFile", class: "custom-file-input", required: true
+        = f.file_field :images, multiple: true, id: "customFile", class: "custom-file-input", required: @listing.new_record?
         %label.custom-file-label{ for: "customFile" } Choose file
     .mt-2.mb-2#preview-images-container
 


### PR DESCRIPTION
This form validation makes you upload an image when updating a listing,
even when the listing already has an image. I opted to make it required
only for new listings, though another alternative would be to make it
`@listing.images.empty?`. The reason I chose this is that a user might
want to update the record for another reason, so doesn't make sense for
someone to have to upload an image in that case.