### PR TITLE
Bugs: fix else case when creating listing

### DIFF
--- a/app/controllers/listings_controller.rb
+++ b/app/controllers/listings_controller.rb
@@ -33,6 +33,9 @@ class ListingsController < ApplicationController
       @listing_categories = []
       flash[:danger] = "Something has gone horribly wrong. Listing not created."
       @currencies = Currency.all
+      @categories = Category.all.pluck(:name)
+      @all_categories = Category.all.pluck(:name)
+      @listing_categories = []
       render :new
     end
   end


### PR DESCRIPTION
When the listing is not valid, it re-renders the `new` template, but
throws an error because it's missing these variables.