### PR TITLE
Views: add `satoshi_image` helper

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :null_session, if: proc { |c| c.request.format == "application/json" }
   helper_method :current_user
   helper_method :google_maps_api_key
+  helper_method :satoshi_image
 
   before_action :fake_ip unless Rails.env.production?
   before_action :detect_device_variant
@@ -47,5 +48,10 @@ class ApplicationController < ActionController::Base
 
   def set_google_analytics_key
     gon.google_analytics_key = ENV.fetch("GOOGLE_ANALYTICS_KEY")
+  end
+
+  def satoshi_image(width:)
+    "https://www.thesun.co.uk/wp-content/uploads" \
+      "/2017/11/nintchdbpict000074010725.jpg?strip=all&w=#{width}"
   end
 end

--- a/app/views/listings/_carousel.html.haml
+++ b/app/views/listings/_carousel.html.haml
@@ -18,8 +18,7 @@
           - if @listing.images.attached?
             %img.d-block.w-100{ alt: "First slide", src: url_for(@listing.images.first) }
           - else
-            %img.d-block.w-100{ alt: "First slide",
-                                src: "https://www.thesun.co.uk/wp-content/uploads/2017/11/nintchdbpict000074010725.jpg?strip=all&w=960 " }
+            %img.d-block.w-100{ alt: "First slide", src: satoshi_image(width: 960) }
         - @listing.images.drop(1).each do |image|
           .carousel-item
             %img.d-block.w-100{ alt: "First slide", src: url_for(image) }

--- a/app/views/listings/_non_google_place_details.html.haml
+++ b/app/views/listings/_non_google_place_details.html.haml
@@ -38,7 +38,7 @@
 
 - else
   .card#no-listing-found
-    %img.card-img-top{ src: "https://www.thesun.co.uk/wp-content/uploads/2017/11/nintchdbpict000074010725.jpg?strip=all&w=500", width: "300" }
+    %img.card-img-top{ src: satoshi_image(width: 300) }
     .card-body
       %h4.card-title No listings found for your search location
       %p.card-text Satoshi suggests searching somewhere else

--- a/app/views/listings/index.html.haml
+++ b/app/views/listings/index.html.haml
@@ -33,7 +33,7 @@
                 - elsif listing.images.attached?
                   = image_tag listing.images.last
                 - else
-                  = image_tag "https://www.thesun.co.uk/wp-content/uploads/2017/11/nintchdbpict000074010725.jpg?strip=all&w=960"
+                  = image_tag satoshi_image(width: 960)
 
     .col.sm-8#map-photos-details
 

--- a/app/views/mobile_views/listings/_non_google_place_details.html.haml
+++ b/app/views/mobile_views/listings/_non_google_place_details.html.haml
@@ -31,7 +31,7 @@
 
 - else
   .card#no-listing-found
-    %img.card-img-top{ src: "https://www.thesun.co.uk/wp-content/uploads/2017/11/nintchdbpict000074010725.jpg?strip=all&w=500", width: "300" }
+    %img.card-img-top{ src: satoshi_image(width: 300) }
     .card-body
       %h4.card-title No listings found for your search location
       %p.card-text Satoshi suggests searching somewhere else

--- a/app/views/mobile_views/listings/index.html.haml
+++ b/app/views/mobile_views/listings/index.html.haml
@@ -46,7 +46,7 @@
                 - elsif listing.images.attached?
                   = image_tag listing.images.last
                 - else
-                  = image_tag "https://www.thesun.co.uk/wp-content/uploads/2017/11/nintchdbpict000074010725.jpg?strip=all&w=960"
+                  = image_tag satoshi_image(width: 960)
 
   .row
     .col#map-photos


### PR DESCRIPTION
Since we use this in so many places, seems worth pulling out rather than
copying and pasting it over and over. I made a judgement call on
`width:`, as in some places the width was different in the url than
specified for the image. Not sure if this was intentional, but I opted
to just use the url width.